### PR TITLE
mirror: fix mirror reflection broken in Three.js r183

### DIFF
--- a/mirror/src/index.js
+++ b/mirror/src/index.js
@@ -107,6 +107,7 @@ const baseComponent = {
 
 		// Temporary camera objects to hold the state before reflecting
 		this.tempCamera = new THREE.PerspectiveCamera();
+		this.tempCamera.matrixWorldAutoUpdate = false;
 		this.tempCameras = [new THREE.PerspectiveCamera(), new THREE.PerspectiveCamera()];
 
 		// Setup clipping plane


### PR DESCRIPTION
Claude Code Opus 4.6 found the issue and fix. Here is what Claude said:

Mirrors are broken since Three.js r183. The reflection appears reversed — the avatar is seen from behind, and the scene is not properly mirrored.     
                  
## Root cause                                                                                                                                                                                                   
                  
Commit https://github.com/mrdoob/three.js/commit/6e4cc1ed26697f4f74e1a346e0394a7a40d58ce5 — "Camera: Exclude scale from view matrix" changed `Camera.updateMatrixWorld()` to strip non-unit scale from `matrixWorldInverse` for glTF conformance.
                                                                                                                                                                                                                  
A mirror reflection matrix has a negative determinant. When decomposed, this gives `scale.x = -1`. The new code detects `scale !== (1,1,1)` and recomposes `matrixWorldInverse` **without the scale**, destroying the reflection.
                                                                                                                                                                                                                  
## Sequence     

1. Mirror sets `tempCamera.matrixWorld` to the reflected camera matrix (negative determinant, `scale.x = -1`)                                                                                                   
2. Mirror sets `tempCamera.matrixWorldInverse` to the correct inverse
3. `renderer.render()` calls `camera.updateMatrixWorld()` (since `camera.parent === null && camera.matrixWorldAutoUpdate === true`)                                                                             
4. **r183**: `updateMatrixWorld` decomposes the matrix, sees `scale ≠ (1,1,1)`, recomposes `matrixWorldInverse` with `scale(1,1,1)` — dropping the reflection                                                   
                                                                                                                                                                                                                  
## Fix                                                                                                                                                                                                          
                                                                                                                                                                                                                  
Set `matrixWorldAutoUpdate = false` on the temporary camera used for mirror rendering:

```js
this.tempCamera = new THREE.PerspectiveCamera();
this.tempCamera.matrixWorldAutoUpdate = false;                                                                                                                                                                  
```  
This prevents renderer.render() from overwriting the manually set matrices.                                                                                                                                     
 